### PR TITLE
Limit SCSS linting to the src and site folders

### DIFF
--- a/script/travis_script.sh
+++ b/script/travis_script.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
-scss-lint .
+scss-lint src site
 grunt travis


### PR DESCRIPTION
Prevents running SCSS lint on dependencies
