### PR TITLE
Clean Content page-specific instructions

### DIFF
--- a/site/pages/docs/ref/theme-gc-intranet/theme-gc-intranet-en.hbs
+++ b/site/pages/docs/ref/theme-gc-intranet/theme-gc-intranet-en.hbs
@@ -55,7 +55,7 @@
 		<ol>
 			<li>Correct the menu bar links or <a href="../../../content-nositemenubc-en.html">remove the menu bar</a></li>
 			<li>Correct the <strong>English/<span lang="fr">Français</span></strong> link or <a href="../../../content-nosearchlang-en.html">remove the language selection link</a></li>
-			<li><strong>Optional:</strong> Optional: <a href="<a href="../../../content-subsite-en.html">">Add a sub-site title</a></li>
+			<li><strong>Optional:</strong> Optional: <a href="../../../content-subsite-en.html">Add a sub-site title</a></li>
 			<li><strong>Optional:</strong> Implement the <a href="../../../content-secmenu-en.html">secondary menu</a> (maximum of 2 levels)</li>
 			<li>Correct the search field or <a href="../../../content-nosearchlang-en.html">remove the search field</a></li>
 			<li>Correct the breadcrumb trail or <a href="../../../content-nositemenubc-en.html">remove the breadcrumb trail</a></li>


### PR DESCRIPTION
duplication of  <a href=" (copy-and-paste error) prevents the line from being processed properly.
This change removes the extraneous characters and thus correct the specific instructions.
It removes duplicate  <a href=" and duplicate "> within line 58