### PR TITLE
Build: Excluded minified CSS/JS files as sources in minification tasks.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -322,7 +322,10 @@ module.exports = (grunt) ->
 			theme:
 				expand: true
 				cwd: "<%= themeDist %>/css"
-				src: "*.css"
+				src: [
+					"*.css"
+					"!*.min.css"
+				]
 				ext: ".min.css"
 				dest: "<%= themeDist %>/css"
 
@@ -357,7 +360,10 @@ module.exports = (grunt) ->
 					banner: "<%= banner %>"
 				expand: true
 				cwd: "<%= themeDist %>"
-				src: "**/*.js"
+				src: [
+					"**/*.js"
+					"!**/*.min.js"
+				]
 				dest: "<%= themeDist %>"
 				ext: ".min.js"
 


### PR DESCRIPTION
The Gruntfile's cssmin and uglify tasks were previously configured to treat almost any CSS/JS file as source. However, if a user repeatedly ran either of those tasks, pre-existing minified files would inadvertently be treated as extra sources. The end result was that the minified files grew each time those tasks ran. Each time they ran, freshly-minified code originating from unminified files seemed to get prepended to the pre-existing minified files, followed by combined files getting minified yet again.

As a result, minified files would continuously grow. If any source files were changed while preparing a PR, the changes would be overridden by outdated code situated at the end of the updated minified files.

Related to wet-boew/GCWeb#1307.

@LaurentGoderre @nschonni FYI.