### PR TITLE
Server message pages: Removed line break before HTML doctype.

### DIFF
--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -2,8 +2,7 @@
 {
 	"officiallanguage": "<%= language === 'en' || language === 'fr' %>"
 }
----
-<!DOCTYPE html>
+---<!DOCTYPE html>
 <!--[if lt IE 9]><html class="no-js lt-ie9" lang="{{language}}" dir="{{{i18n "lang-dir"}}}"><![endif]-->
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="{{language}}" dir="{{{i18n "lang-dir"}}}">


### PR DESCRIPTION
One of #171's changes introduced a line break before the HTML doctype in all unminified server message page templates. wet-boew/theme-gcwu-fegc#251's discussion indicated that may potentially prevent HTML standards mode from activating in certain browsers. Plus it looks strange for generated HTML pages to not immediately start off with a doctype.

This commit removes the line break by placing the YFM block's 3 closing dashes and the HTML doctype on the same line.

@LaurentGoderre @nschonni FYI.