### PR TITLE
Theme: Reference SVG logos with img element instead of object.

### DIFF
--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -2,5 +2,5 @@
 	<a href="{{site.wetSiteRoot}}/index-{{language}}.html">
 		<span>{{{i18n "site-title"}}}</span>
 	</a>
-	<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-intra.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>
+	<img id="wmms" src="{{assets}}/../{{site.theme}}/assets/wmms-intra.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />
 </div>

--- a/site/includes/headerbar.hbs
+++ b/site/includes/headerbar.hbs
@@ -3,7 +3,7 @@
 	"officiallanguage": "<%= language === 'en' || language === 'fr' %>"
 }
 ---
-<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-blk-{{#is headerbar.officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt headerbar.officiallanguage "true"}} lang="{{{site.defaultLanguage}}}"{{/isnt}}></object>
+<img id="gcwu-sig" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{#is headerbar.officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" alt="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt headerbar.officiallanguage "true"}} lang="{{{site.defaultLanguage}}}"{{/isnt}} />
 {{#isnt languagetoggle "false"}}
 	{{>languagetoggle}}
 {{/isnt}}

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -23,10 +23,10 @@
 			<div class="container">
 				<div class="row">
 					<div class="col-sm-6">
-						<object id="gcwu-sig" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/sig-blk-{{#is officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" aria-label="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt officiallanguage "true"}} lang="{{site.defaultLanguage}}"{{/isnt}}></object>
+						<img id="gcwu-sig" src="{{assets}}/../{{site.theme}}/assets/sig-blk-{{#is officiallanguage "true"}}{{language}}{{else}}{{site.defaultLanguage}}{{/is}}.svg" alt="{{#is page.language "fr"}}{{{i18n "tmpl-gc-sig"}}} / {{{i18n "tmpl-gc-sig" language="en"}}}{{else}}{{{i18n "tmpl-gc-sig" language="en"}}} / {{{i18n "tmpl-gc-sig" language="fr"}}}{{/is}}"{{#isnt officiallanguage "true"}} lang="{{site.defaultLanguage}}"{{/isnt}} />
 					</div>
 					<div class="col-sm-6">
-						<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/wmms-intra.svg" aria-label="{{{i18n "tmpl-gc-wmms"}}}"></object>
+						<img id="wmms" src="{{assets}}/../{{site.theme}}/assets/wmms-intra.svg" alt="{{{i18n "tmpl-gc-wmms"}}}" />
 					</div>
 				</div>
 			</div>

--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -20,7 +20,7 @@
 			<div class="container">
 				<div class="row mrgn-tp-lg mrgn-bttm-lg">
 					<div class="col-md-8 col-md-offset-2">
-						<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/logo.svg" aria-label="{{{i18n "site-title"}}}"></object>
+						<img src="{{assets}}/../{{site.theme}}/assets/logo.svg" alt="{{{i18n "site-title"}}}" />
 					</div>
 				</div>
 			</div>

--- a/src/assets/wmms-intra.svg
+++ b/src/assets/wmms-intra.svg
@@ -5,7 +5,10 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#F00;}
-			@media screen and (min-height: 2.2em) {.fip_text, .fip_flag {fill:#FFF;}}
+			@media screen and (min-height: 2.2em) and (-ms-high-contrast: none),
+			screen and (min-height: 2.2em) and (-ms-high-contrast: active) {
+				.fip_text, .fip_flag {fill: #FFF;}
+			}
 		</style>
 	</defs>
 	<g id="wmms" transform="translate(-1, -1)">

--- a/src/theme.js
+++ b/src/theme.js
@@ -15,11 +15,11 @@ var $document = wb.doc,
 	$fipImg,
 
 	onSmallView = function() {
-		$fipImg.attr( "src", $fipImg.attr( "src" ).replace( "wmms-intra", "wmms" ) );
+		$fipImg.attr( "src", $fipImg.attr( "src" ).replace( "wmms-intra.png", "wmms.png" ) );
 	},
 
 	onMediumLargeView = function() {
-		$fipImg.attr( "src", $fipImg.attr( "src" ).replace( /wmms\./, "wmms-intra." ) );
+		$fipImg.attr( "src", $fipImg.attr( "src" ).replace( /wmms\.png/, "wmms-intra.png" ) );
 	};
 
 $document.one( "timerpoke.wb", function() {

--- a/src/views/_screen-md-min.scss
+++ b/src/views/_screen-md-min.scss
@@ -28,7 +28,10 @@
 
 #wmms {
 	height: 1.9em;
-	margin-top: -2.5em;
+	margin: {
+		bottom: .375em;
+		top: -2.5em;
+	}
 	position: absolute;
 	right: $header-margin;
 	top: -5px;
@@ -36,7 +39,7 @@
 }
 
 #gcwu-sig {
-	margin: 2.8em 0 .25em $header-margin;
+	margin: 2.8em 0 .625em $header-margin;
 }
 
 #wb-bnr {

--- a/src/views/_screen-sm-max.scss
+++ b/src/views/_screen-sm-max.scss
@@ -25,6 +25,7 @@
 }
 
 #wmms {
+	filter: brightness(0) invert(100%);
 	height: 2.35em;
 	left: 15px;
 	margin-top: -8px;


### PR DESCRIPTION
* Port of wet-boew/wet-boew#8282.
* Related to wet-boew/wet-boew#8276.
* Adds a CSS filter to change the wordmark SVG's colour to white in small view and under:
  * Needed for Gecko, Blink and possibly Webkit due to their buggy handling of inline SVG media queries when the img element is used. When printing, they apply screen-only queries and ignore print-only queries.
* Modifies the wordmark SVG's inline media query to only change its colour to white in Internet Explorer 10-11 small view and under.
  * Since IE10-11 correctly handle the aforementioned media queries but lack support for CSS filters, this is the most viable setup to make the wordmark render correctly in all of WET's supported browsers.
* Modifies the theme's JavaScript logic to only toggle the fallback PNG images when switching between small and under/medium and over views.
* Modifies SCSS to increase the bottom margins on the signature/wordmark images to replicate the empty space that was previously appearing below their object element containers.